### PR TITLE
changes for newer hhvm versions

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -1,9 +1,14 @@
 option(FORCE_TP_JEMALLOC "Always build and statically link jemalloc instead of using system version" OFF)
 option(JEMALLOC_INCLUDE_DIR "The include directory for built & statically linked jemalloc")
+option(DOUBLE_CONVERSION_INCLUDE_DIR "The include directory for built & statically linked double-conversion")
 
 if (FORCE_TP_JEMALLOC)
     # need to include statically-built third-party/jemalloc since the system version is <5 on 18.04
     include_directories(${JEMALLOC_INCLUDE_DIR})
+endif()
+
+if (NOT "$DOUBLE_CONVERSION_INCLUDE_DIR" STREQUAL "")
+        include_directories(${DOUBLE_CONVERSION_INCLUDE_DIR})
 endif()
 
 HHVM_ADD_INCLUDES(grpc_hack ./)

--- a/ext_grpc.cpp
+++ b/ext_grpc.cpp
@@ -180,7 +180,7 @@ protected:
   // where we return data to PHP.
   void unserialize(TypedValue &result) override final {
     auto resp = data_->UnserializeResponse();
-    auto resTuple = make_varray(resp, data_->UnserializeStatus());
+    auto resTuple = make_vec_aarray(resp, data_->UnserializeStatus());
     tvCopy(make_array_like_tv(resTuple.detach()), result);
   }
 };


### PR DESCRIPTION
Fixes two errors on newer hhvm versions:
```
/build/extensions/grpc-hack/ext_grpc.cpp:183:21: error: 'make_varray' was not declared in this scope
     auto resTuple = make_varray(resp, data_->UnserializeStatus());
                     ^~~~~~~~~~~
/build/extensions/grpc-hack/ext_grpc.cpp:183:21: note: suggested alternative: 'make_vec_array'
```

And
```
build/hhvm/third-party/folly/bundled_folly-prefix/include/folly/Conv.h:114:10: fatal error: double-conversion/double-conversion.h: No such file or directory
 #include <double-conversion/double-conversion.h> // V8 JavaScript implementation
```

