### PR TITLE
add proxygen include dir

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -2,6 +2,7 @@ option(FORCE_TP_JEMALLOC "Always build and statically link jemalloc instead of u
 option(JEMALLOC_INCLUDE_DIR "The include directory for built & statically linked jemalloc")
 option(DOUBLE_CONVERSION_INCLUDE_DIR "The include directory for built & statically linked double-conversion")
 option(BOOST_INCLUDE_DIR "The include directory for built & statically linked boost")
+option(PROXYGEN_INCLUDE_DIR "The include directory for built & statically linked proxygen")
 
 if (FORCE_TP_JEMALLOC)
     # need to include statically-built third-party/jemalloc since the system version is <5 on 18.04
@@ -14,6 +15,10 @@ endif()
 
 if (NOT "$BOOST_INCLUDE_DIR" STREQUAL "")
         include_directories(${BOOST_INCLUDE_DIR})
+endif()
+
+if (NOT "$PROXYGEN_INCLUDE_DIR" STREQUAL "")
+        include_directories(${PROXYGEN_INCLUDE_DIR})
 endif()
 
 HHVM_ADD_INCLUDES(grpc_hack ./)


### PR DESCRIPTION
As with double conversion and boost before this, we now need to import proxygen's include dir to fix this build error:
```
17:47:08 [ 50%] Building CXX object CMakeFiles/grpc_hack.dir/ext_grpc.cpp.o
17:47:10 In file included from /build/hhvm/hphp/runtime/base/execution-context.h:27:0,
17:47:10                  from /build/hhvm/hphp/runtime/vm/vm-regs.h:19,
17:47:10                  from /build/hhvm/hphp/runtime/base/array-init.h:31,
17:47:10                  from /build/extensions/grpc-hack/ext_grpc.cpp:3:
17:47:10 /build/hhvm/hphp/runtime/server/transport.h:28:10: fatal error: proxygen/lib/http/HTTPHeaders.h: No such file or directory
17:47:10  #include "proxygen/lib/http/HTTPHeaders.h"
17:47:10           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
17:47:10 compilation terminated.
17:47:10 make[2]: *** [CMakeFiles/grpc_hack.dir/ext_grpc.cpp.o] Error 1
```